### PR TITLE
Disable truffle postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "postinstall": "echo \"\n\n\n\ncontracts included in this project require compilation on a fresh checkout: npm run truffle:compile\n\n\n\n\"",
     "pretest": "./ensure-ganache-running.sh || (npm run start:testrpc &)",
-    "test": "mocha",
+    "test": "npm run truffle:compile && mocha",
     "test:lint": "eslint -c .eslintrc . --color=true --quiet",
     "test:lint:fix": "eslint -c .eslintrc . --color=true --quiet --fix",
     "test:truffle": "cd truffle && truffle test",


### PR DESCRIPTION
i was trying to use this package as a library, and didn't want it running truffle after installing.

it probably makes sense to remove our smart contracts from this package too.